### PR TITLE
forcing kyma to install on kyma-system

### DIFF
--- a/modular-kyma/kyma-init.sh
+++ b/modular-kyma/kyma-init.sh
@@ -1,7 +1,7 @@
 curl -Lo kyma https://storage.googleapis.com/kyma-cli-unstable/kyma-linux # kyma-linux, kyma-linux-arm, kyma.exe, or kyma-arm.exe
 chmod +x kyma
 mv kyma /usr/local/bin/
-kyma alpha deploy --ci
+kyma alpha deploy --ci -n kyma-system
 kubectl apply -f cluster-ip-module-template-fast.yaml
 kubectl taint nodes controlplane node-role.kubernetes.io/control-plane:NoSchedule-
 echo "Kyma Control Plane is ready. Go to next step."


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

it seems that the kyma cli does not use kyma-system as default:

- We force kyma to be installed in kyma-system


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
