### PR TITLE
Remove default module templates from tutorial temporarily

### DIFF
--- a/modular-kyma/modules.md
+++ b/modular-kyma/modules.md
@@ -1,4 +1,4 @@
-You can now enable modules in the Kyma Dashboard. Go to the namespace `kyma-system`, open the Kyma resource (in the `Kyma` section), edit it and add `keda` or `cluster-ip` module from beta channel. 
+You can now enable modules in the Kyma Dashboard. Go to the namespace `kyma-system`, open the Kyma resource (in the `Kyma` section), edit it and add `cluster-ip` module from beta channel. 
 
 Alternatively, feel free to observe all available modules in the cluster with the CLI:
 ```
@@ -13,11 +13,6 @@ kyma alpha list module -k default-kyma
 
 
 If you prefer CLI  also for enabling/disabling the other modules, you can enable them using the same command as before:
-```
-kyma alpha enable module keda --channel alpha --wait
-```{{exec}}
-
-and `cluster-ip` module using this command:
 ```
 kyma alpha enable module cluster-ip --channel fast --wait
 ```{{exec}}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Remove enabling `keda` module temporarily till the default modules get deployed with the `Kyma alpha deploy` command.


**Related issue(s)**
https://github.com/kyma-project/cli/issues/1620